### PR TITLE
change the data type of terms_of_service to suit user input

### DIFF
--- a/mojo/openapi/info.mojo
+++ b/mojo/openapi/info.mojo
@@ -22,7 +22,7 @@ type Info {
     description: Cached<document.Document> @2
 
     /// A URL to the Terms of Service for the API.
-    terms_of_service: Url @3
+    terms_of_service: String @3
 
     /// The contact information for the exposed API.
     contact: Contact @4


### PR DESCRIPTION
虽然 https://spec.openapis.org/oas/v3.0.3 标准里termsOfService必须是个URL，但是无奈很多openapi生成工具生成的openapi中termsOfService都包含“urn:tos”这样的值。
修改termsOfService的数据类型，可以提高本lib对一些非标准openapi的兼容性